### PR TITLE
ci: add trusted fork test workflow with ok-to-test label gate

### DIFF
--- a/.github/workflows/trusted-fork-tests.yml
+++ b/.github/workflows/trusted-fork-tests.yml
@@ -1,0 +1,163 @@
+name: "[Maintainer] Trusted Fork Tests"
+# Allows maintainers to run the full self-hosted CI suite (Build + Gateway Tests)
+# against a fork pull request, after they have reviewed the code.
+#
+# HOW TO USE:
+#   1. Review the fork PR code thoroughly.
+#   2. Add the `ok-to-test` label to the PR.
+#   3. This workflow checks that you have write/maintain/admin permission,
+#      removes the label (so it can be re-added after new commits), creates a
+#      temporary upstream branch at the PR head SHA, and dispatches the
+#      Build and Gateway Test workflows against it.
+#   4. Track progress in the Actions tab or via the link posted in the PR comment.
+#   5. Re-add `ok-to-test` after the contributor pushes new commits to re-trigger.
+#
+# SECURITY MODEL:
+#   - pull_request_target runs in the base repo context (has access to secrets).
+#   - The actor's repository permission is verified before any action is taken.
+#   - Untrusted fork code never executes in this workflow itself; it is only
+#     checked out by the dispatched Build/Gateway workflows, which run under a
+#     separate workflow_dispatch event on the temporary upstream branch.
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: write      # create and delete the temporary upstream branch
+  pull-requests: write # post a status comment on the PR
+  actions: write       # dispatch the Build and Gateway Test workflows
+
+jobs:
+  trigger-trusted-tests:
+    name: Trigger trusted tests for fork PR
+    # Only proceed when the ok-to-test label is added on a fork PR.
+    # Same-repo PRs already pass CI directly and do not need this path.
+    if: |
+      github.event.label.name == 'ok-to-test' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.3.1
+        with:
+          egress-policy: audit
+
+      # Verify that the person who added the label has write-level access or higher.
+      # This prevents contributors from triggering self-hosted runners on their own PRs
+      # by adding the label themselves.
+      - name: Check actor permission
+        id: check-permission
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PERMISSION=$(gh api \
+            "repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission" \
+            --jq '.permission' 2>/dev/null || echo "none")
+          echo "permission=${PERMISSION}"
+          if [[ "$PERMISSION" == "write" || "$PERMISSION" == "maintain" || "$PERMISSION" == "admin" ]]; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # If the actor lacks permission, remove the label and leave an explanatory comment.
+      - name: Remove label and notify (unauthorized actor)
+        if: steps.check-permission.outputs.authorized == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/ok-to-test" \
+            -X DELETE
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "> [!CAUTION]
+          > @${{ github.actor }} does not have write access to this repository.
+          > Only maintainers with write, maintain, or admin permission can trigger trusted fork tests.
+          > The \`ok-to-test\` label has been removed."
+
+      # Remove the label immediately so a maintainer can re-add it after new commits
+      # to trigger a fresh test run without having to manually clear a stale label.
+      - name: Remove label (allows re-triggering after new commits)
+        if: steps.check-permission.outputs.authorized == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/ok-to-test" \
+            -X DELETE
+
+      # Create a short-lived upstream branch at the exact PR head SHA.
+      # workflow_dispatch requires a ref that exists in the base repository;
+      # this branch satisfies that requirement without permanently mirroring the fork branch.
+      - name: Create temporary upstream branch at PR head SHA
+        if: steps.check-permission.outputs.authorized == 'true'
+        id: create-branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          TEMP_BRANCH="ci/trusted/pr-${PR_NUMBER}"
+          echo "temp_branch=${TEMP_BRANCH}" >> "$GITHUB_OUTPUT"
+
+          # Remove any leftover branch from a previous run on this PR.
+          gh api "repos/${{ github.repository }}/git/refs/heads/${TEMP_BRANCH}" \
+            -X DELETE 2>/dev/null || true
+
+          # Create the branch at the approved PR head SHA.
+          gh api "repos/${{ github.repository }}/git/refs" \
+            -f "ref=refs/heads/${TEMP_BRANCH}" \
+            -f "sha=${PR_SHA}"
+
+      - name: Dispatch [Blocking] Build workflow
+        if: steps.check-permission.outputs.authorized == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yml \
+            --ref "${{ steps.create-branch.outputs.temp_branch }}" \
+            --repo "${{ github.repository }}"
+
+      - name: Dispatch [Integration] Gateway Tests workflow
+        if: steps.check-permission.outputs.authorized == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run test.yml \
+            --ref "${{ steps.create-branch.outputs.temp_branch }}" \
+            --repo "${{ github.repository }}"
+
+      - name: Post status comment on PR
+        if: steps.check-permission.outputs.authorized == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "> [!NOTE]
+          > 🚀 **Trusted fork tests triggered** by @${{ github.actor }} for commit \`${{ github.event.pull_request.head.sha }}\`.
+          >
+          > The following workflows have been dispatched on a temporary upstream branch:
+          > - **[\[Blocking\] Build](https://github.com/${{ github.repository }}/actions/workflows/build.yml)**
+          > - **[\[Integration\] Gateway Tests](https://github.com/${{ github.repository }}/actions/workflows/test.yml)**
+          >
+          > Track progress in the [Actions tab](https://github.com/${{ github.repository }}/actions).
+          >
+          > ℹ️ The \`ok-to-test\` label has been removed. Re-add it after new commits to trigger a fresh run."
+
+      # Delete the temporary branch. The dispatched workflow runs already have the
+      # commit SHA recorded (github.sha is set at dispatch time), so actions/checkout
+      # will succeed by SHA even after this branch reference is removed.
+      - name: Delete temporary upstream branch
+        if: steps.check-permission.outputs.authorized == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Brief pause to allow GitHub Actions to register the dispatched runs
+          # before the ref is removed.
+          sleep 10
+          gh api \
+            "repos/${{ github.repository }}/git/refs/heads/${{ steps.create-branch.outputs.temp_branch }}" \
+            -X DELETE || true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,30 @@ Once you can successfully `make` the project, any code contributions should also
 
 Pull requests will also be expected to pass the PR functional tests specified by `.github/workflows/build.yml`.
 
+### Testing Fork Pull Requests (Maintainers)
+
+For security reasons, the self-hosted CI runners (used by the `[Blocking] Build` and `[Integration] Gateway Tests` workflows) do not automatically run on pull requests submitted from forks. This prevents untrusted code from executing on project infrastructure.
+
+Maintainers can trigger the full test suite against a fork PR using the `ok-to-test` label:
+
+**One-time setup (repo admins only):** Create a label named `ok-to-test` in the repository's Labels settings page.
+
+**To trigger tests on a fork PR:**
+
+1. Review the PR code thoroughly to confirm it is safe to run.
+2. Add the `ok-to-test` label to the PR.
+3. The `[Maintainer] Trusted Fork Tests` workflow will automatically:
+   - Verify you have write/maintain/admin permission (removes the label and posts a notice if not).
+   - Remove the label (so it can be re-added after new commits).
+   - Dispatch the `[Blocking] Build` and `[Integration] Gateway Tests` workflows against the exact PR head SHA.
+   - Post a comment on the PR with links to the running workflows.
+4. Track progress in the [Actions tab](https://github.com/project-copacetic/copacetic/actions) or via the link in the PR comment.
+
+**To re-trigger after new commits:** Simply re-add the `ok-to-test` label. Each application of the label triggers one fresh test run.
+
+> [!IMPORTANT]
+> Only add `ok-to-test` after you have reviewed the contributed code. The label causes the fork's code to execute on project self-hosted runners with access to repository secrets.
+
 ### Pull Requests
 
 If you'd like to start contributing code to the project, you can search for [issues with the `good first issue` label](https://github.com/project-copacetic/copacetic/labels/good%20first%20issue). Other kinds of PR contributions we would look for include:


### PR DESCRIPTION
- New [Maintainer] Trusted Fork Tests workflow (trusted-fork-tests.yml)
- Runs on pull_request_target labeled event with ok-to-test label
- Verifies actor has write/maintain/admin permission
- Creates temporary upstream branch and dispatches Build + Gateway Tests
- Deletes temp branch after dispatch
- Documentation in CONTRIBUTING.md for maintainers

<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Describe the changes in this pull request using active verbs such as _Add_, _Remove_, _Replace_ ...

Closes #<_issue_ID_>
